### PR TITLE
Add 'sudo' dependency

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -5,3 +5,4 @@ dehydrated_deps:
   - wget
   - curl
   - openssl
+  - sudo


### PR DESCRIPTION
'sudo' package is needed by dehydrated, even if dehydrated user is set to root